### PR TITLE
feat!: piped output reader, only emit new process output instead of all

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Send JSON requests (one per line):
 
 **Response**
 ```json
-{"status":"success","data":{"exit_status":0,"pid":440,"stderr":"","stdout":"Li4uc3Rkb3V0IG91dHB1dC4uLgo="}}
+{"status":"success","data":{"exit_status":0,"pid":440,"output":"Li4uc3Rkb3V0IG91dHB1dC4uLgo="}}
 ```
 
 #### Shutdown

--- a/src/process_log_writer.rs
+++ b/src/process_log_writer.rs
@@ -1,6 +1,5 @@
 use log::{error, info};
-use std::io::{BufRead, BufReader};
-use std::process::{ChildStderr, ChildStdout};
+use std::io::{BufRead, BufReader, PipeReader};
 use std::thread;
 
 pub struct ProcessLogWriter {
@@ -12,53 +11,28 @@ impl ProcessLogWriter {
         Self { service_name }
     }
 
-    pub fn log_line(&self, line: &str, is_stderr: bool) {
+    pub fn log_line(&self, line: &str) {
         let trimmed = line.trim();
         if !trimmed.is_empty() {
-            let level = if is_stderr { "ERROR" } else { "INFO" };
-            let log_message = format!("[{}] {}: {}", self.service_name, level, trimmed);
-
-            if is_stderr {
-                error!("{log_message}");
-            } else {
-                info!("{log_message}");
-            }
+            let log_message = format!("[{}] {}", self.service_name, trimmed);
+            info!("{log_message}");
         }
     }
 }
 
 pub fn spawn_output_logger(
     service_name: String,
-    stdout: Option<ChildStdout>,
-    stderr: Option<ChildStderr>,
+    output_reader: PipeReader,
 ) {
-    // Spawn thread for stdout
-    if let Some(stdout) = stdout {
-        let service_name_clone = service_name.clone();
-        thread::spawn(move || {
-            let writer = ProcessLogWriter::new(service_name_clone.clone());
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                match line {
-                    Ok(line) => writer.log_line(&line, false),
-                    Err(e) => error!("[{service_name_clone}] Failed to read stdout: {e}"),
-                }
+    let service_name_clone = service_name.clone();
+    thread::spawn(move || {
+        let writer = ProcessLogWriter::new(service_name_clone.clone());
+        let reader = BufReader::new(output_reader);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => writer.log_line(&line),
+                Err(e) => error!("[{service_name_clone}] Failed to read output: {e}"),
             }
-        });
-    }
-
-    // Spawn thread for stderr
-    if let Some(stderr) = stderr {
-        let service_name_clone = service_name.clone();
-        thread::spawn(move || {
-            let writer = ProcessLogWriter::new(service_name_clone.clone());
-            let reader = BufReader::new(stderr);
-            for line in reader.lines() {
-                match line {
-                    Ok(line) => writer.log_line(&line, true),
-                    Err(e) => error!("[{service_name_clone}] Failed to read stderr: {e}"),
-                }
-            }
-        });
-    }
+        }
+    });
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -158,11 +158,10 @@ where
                     }
                     Ok(RpcRequest::OneshotStatus { pid }) => {
                         match pm.oneshot_status(pid) {
-                            Ok((stdout_b64, stderr_b64, exit_status)) => RpcResponse::Success {
+                            Ok((process_output_b64, exit_status)) => RpcResponse::Success {
                                 data: serde_json::json!({
                                     "pid": pid,
-                                    "stdout": stdout_b64,
-                                    "stderr": stderr_b64,
+                                    "output": process_output_b64,
                                     "exit_status": exit_status
                                 }),
                             },


### PR DESCRIPTION
Response to `oneshotStatus` has changed.

Change from 

```
{"status":"success","data":{"exit_status":0,"pid":440,"stderr":"","stdout":"Li4uc3Rkb3V0IG91dHB1dC4uLgo="}}

```

to

```
{"status":"success","data":{"exit_status":0,"pid":440,"output":"Li4uc3Rkb3V0IG91dHB1dC4uLgo="}}
```